### PR TITLE
Fixing issue with failing Pester tests

### DIFF
--- a/SampleModule.build.ps1
+++ b/SampleModule.build.ps1
@@ -37,6 +37,10 @@ Enter-Build {
     # Installing dependencies
     Invoke-PSDepend -Force
 
+    # Removing all loaded versions of Pester and importing the specific Pester 4 version
+    Get-Module -Name Pester | Remove-Module
+    Import-Module -Name Pester -RequiredVersion 4.10.1
+
     # Setting build script variables
     $script:moduleName = 'SampleModule'
     $script:moduleSourcePath = Join-Path -Path $BuildRoot -ChildPath $moduleName

--- a/SampleModule.depend.psd1
+++ b/SampleModule.depend.psd1
@@ -1,6 +1,6 @@
 @{
     # Build dependencies
-    Pester                     = @{ target = 'CurrentUser'; version = 'latest' }
+    Pester                     = @{ target = 'CurrentUser'; version = '4.10.1' }
     PSScriptAnalyzer           = @{ target = 'CurrentUser'; version = 'latest' }
     PlatyPS                    = @{ target = 'CurrentUser'; version = 'latest' }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ trigger:
     include:
       - master
       - feature/*
+      - bugfix/*
   paths:
     exclude:
       - README.md


### PR DESCRIPTION
As a workaround, locked down the build environment to use Pester 4 as the test format has changed in Pester 5. That fixes #1